### PR TITLE
Use Ansible Galaxy to manage and install the fork of AVD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+ansible_collections/

--- a/README.md
+++ b/README.md
@@ -20,12 +20,11 @@
 ```shell
   # Clone repositories
   git clone https://github.com/carlbuchmann/AVD-US-PROJECT-01.git
-  git clone https://github.com/aristanetworks/ansible-avd.git
+  cd AVD-US-PROJECT-01/
+  # Install Ansible AVD branch
+  ansible-galaxy collection install -r ansible-galaxy.yml
   # Copy Makefile to folder, this will be used to start AVD Team container
   cp ansible-avd/development/Makefile Makefile
-  # Change to PR #1000 branch
-  cd ansible-avd
-  gh pr checkout 1000
   # Start AVD Team container
   cd ..
   make run

--- a/ansible-galaxy.yml
+++ b/ansible-galaxy.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name:  https://github.com/ClausHolbechArista/ansible-avd.git#ansible_collections/arista/avd
+    type: git
+    version: disagg-topology-support

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,7 +11,7 @@ duplicate_dict_key = error
 filter_plugins = ansible-avd/plugins/filters
 roles_path = roles/:ansible-avd/roles
 library = ansible-avd/library
-collections_paths = ../ansible-cvp:../ansible-avd:~/.ansible/collections:/usr/share/ansible/collections
+collections_paths = ./
 
 # Increase forks
 forks = 15


### PR DESCRIPTION
This also changes ansible.cfg to install all required collections
locally in the repo. This prevents the mixing of collections across
projects.